### PR TITLE
fix(ruby): strikethrough formatting in table

### DIFF
--- a/lib/md_to_pdf/elements/html.rb
+++ b/lib/md_to_pdf/elements/html.rb
@@ -120,6 +120,8 @@ module MarkdownToPDF
             process_children, current_opts = handle_unknown_html_tag(sub, node, current_opts)
             draw_html_tag(sub, node, opts) if process_children
           end
+        when 's'
+          result.concat(data_inlinehtml_tag(sub, node, opts.merge({ styles: [:strikethrough] })))
         else
           data_array, current_opts = handle_unknown_inline_html_tag(sub, node, current_opts)
           result.concat(data_array)


### PR DESCRIPTION
### Openproject Workspace with striked text in table

<img width="1906" alt="Screenshot 2025-04-19 at 6 58 53 PM" src="https://github.com/user-attachments/assets/1122f944-8593-4c62-b481-c2859a0eb3c5" />


### Here is the generated PDF after fix

<img width="932" alt="Screenshot 2025-04-19 at 7 00 03 PM" src="https://github.com/user-attachments/assets/130b0ff7-557b-4f75-a1e9-f44e59089b73" />
